### PR TITLE
Decode hmac cipher, adjust notify windows

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -135,7 +135,7 @@ func (b *Bot) NotifyNewItems(termEN, userID string, items []sendico.Item) error 
 			shop = b.emojis.For(item.Shop.Identifier()) + " " + shop
 		}
 
-		embeds = append(embeds, &discordgo.MessageEmbed{
+		embed := &discordgo.MessageEmbed{
 			Title: item.Name,
 			Image: &discordgo.MessageEmbedImage{
 				URL: item.Image,
@@ -151,14 +151,19 @@ func (b *Bot) NotifyNewItems(termEN, userID string, items []sendico.Item) error 
 					Value:  shop,
 					Inline: true,
 				},
-				{
-					Name:   "Category",
-					Value:  item.Category.String(),
-					Inline: true,
-				},
 			},
 			URL: item.SendicoLink(),
-		})
+		}
+
+		if item.Category != nil {
+			embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+				Name:   "Category",
+				Value:  item.Category.String(),
+				Inline: true,
+			})
+		}
+
+		embeds = append(embeds, embed)
 	}
 
 	msg, err := b.session.ChannelMessageSendComplex(dm.ID, &discordgo.MessageSend{

--- a/internal/looper/looper.go
+++ b/internal/looper/looper.go
@@ -12,11 +12,11 @@ import (
 )
 
 const (
-	TickNotify  = 2 * time.Minute
+	TickNotify  = 5 * time.Minute
 	TickCleanup = 1 * time.Hour
-	TickRefresh = 5 * time.Minute
+	TickRefresh = 30 * time.Minute
 
-	WindowNotify  = 5 * time.Minute
+	WindowNotify  = 10 * time.Minute
 	WindowCleanup = 72 * time.Hour
 )
 
@@ -44,7 +44,7 @@ func (l *Looper) Notify(ctx context.Context) {
 			return
 		case <-ticker.C:
 			// the following search/check/notify flow will probably not scale well. should be fine for low volume though
-			termSubs, err := l.db.FindSubscriptionsToNotify(WindowNotify, 100)
+			termSubs, err := l.db.FindSubscriptionsToNotify(WindowNotify, 250)
 			if err != nil {
 				log.Error("failed to find terms to update", "err", err)
 				continue

--- a/pkg/sendico/client.go
+++ b/pkg/sendico/client.go
@@ -107,7 +107,7 @@ func (c *Client) FindHMAC(ctx context.Context) error {
 	for _, obj := range unstruct {
 		switch v := obj.(type) {
 		case map[string]any:
-			if val, ok := v["$ssecret_keys"]; ok {
+			if val, ok := v["$sapi_tokens"]; ok {
 				ptr = int64(val.(float64))
 				break
 			}
@@ -120,15 +120,15 @@ func (c *Client) FindHMAC(ctx context.Context) error {
 
 	keyPtrs := unstruct[ptr].([]any)
 	secretKeys := make([]string, len(keyPtrs))
-	for _, keyPtr := range keyPtrs {
-		secretKeys = append(secretKeys, unstruct[int64(keyPtr.(float64))].(string))
+	for i, keyPtr := range keyPtrs {
+		secretKeys[i] = unstruct[int64(keyPtr.(float64))].(string)
 	}
 
 	if len(secretKeys) == 0 {
 		return errors.New("no secret keys found")
 	}
 
-	newSecret := secretKeys[len(secretKeys)-1]
+	newSecret := DecodeHMACKey(secretKeys[len(secretKeys)-1])
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	changed := c.hmacSecret != newSecret

--- a/pkg/sendico/hmac.go
+++ b/pkg/sendico/hmac.go
@@ -5,10 +5,16 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+const (
+	CaesarShift = -3
 )
 
 type HMACInput struct {
@@ -54,4 +60,22 @@ func BuildHMAC(in HMACInput) (*HMACAttributes, error) {
 		Nonce:     in.Nonce,
 		Timestamp: in.Timestamp,
 	}, nil
+}
+
+func DecodeHMACKey(key string) string {
+	decoded := make([]rune, len(key))
+	for i, char := range key {
+		if char >= 'a' && char <= 'z' {
+			decoded[i] = 'a' + (char-'a'+CaesarShift+26)%26
+		} else if char >= 'A' && char <= 'Z' {
+			decoded[i] = 'A' + (char-'A'+CaesarShift+26)%26
+		} else {
+			decoded[i] = char
+		}
+	}
+
+	decodedPieces := strings.Split(string(decoded), " ")
+	slices.Reverse(decodedPieces)
+
+	return strings.Join(decodedPieces, " ")
 }

--- a/pkg/sendico/hmac_test.go
+++ b/pkg/sendico/hmac_test.go
@@ -26,3 +26,9 @@ func TestBuildHMAC(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, out.Signature, "2545fcd9e8b72d3e7be95affebcb080e444e2a2516329727c6bd9f3587833d4a")
 }
+
+func TestDecodeHMACKey(t *testing.T) {
+	key := "pdwwkhzv pduvkdoo orfnv ehq dpholdexujk"
+	decoded := sendico.DecodeHMACKey(key)
+	assert.Equal(t, "ameliaburgh ben locks marshall matthews", decoded)
+}


### PR DESCRIPTION
See: https://github.com/robherley/sendibot/issues/8#issuecomment-2716258014

Also fixes a panic when `item.Category` is nil.